### PR TITLE
Fix #1 - Events being logged with incorrect time

### DIFF
--- a/Warden.Integrations.Seq/SeqIntegrationConfiguration.cs
+++ b/Warden.Integrations.Seq/SeqIntegrationConfiguration.cs
@@ -13,7 +13,6 @@ namespace Warden.Integrations.Seq
         public static readonly JsonSerializerSettings DefaultJsonSerializerSettings = new JsonSerializerSettings
         {
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-            DateFormatString = "yyyy-MM-dd H:mm:ss",
             Formatting = Formatting.Indented,
             DefaultValueHandling = DefaultValueHandling.Populate,
             NullValueHandling = NullValueHandling.Include,


### PR DESCRIPTION
Remove custom date format string.  All dates are now formatted using newtonsoft json's default datetime format ("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") which contains offset info.  Fixes #1 

Sorry about the delay!